### PR TITLE
移除Fabric API依赖以及代码优化

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	// modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
-	minecraft_version=1.16.1
-	yarn_mappings=1.16.1+build.1
-	loader_version=0.8.8+build.202
+# check these on https://fabricmc.net/use
+minecraft_version=1.16.3
+yarn_mappings=1.16.3+build.11
+loader_version=0.9.3+build.207
 
 # Mod Properties
-	mod_version = 1.0.7
-	maven_group = com.ddwhm.jesen
-	archives_base_name = imblockerfabric
-
-# Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.13.1+build.370-1.16
+mod_version = 1.0.7
+maven_group = com.ddwhm.jesen
+archives_base_name = imblockerfabric

--- a/src/main/java/com/ddwhm/jesen/imblocker/IMManager.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/IMManager.java
@@ -4,7 +4,6 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef;
 import com.sun.jna.platform.win32.WinNT;
-import jdk.nashorn.internal.ir.Flags;
 
 public class IMManager {
     public static int flag = 0;
@@ -36,7 +35,7 @@ public class IMManager {
 
 
     public static void makeOn() {
-        if(IMManager.flag == 2001 || IMManager.flag == 500){
+        if (IMManager.flag == 2001 || IMManager.flag == 500) {
             return;
         }
         IMManager.flag = 2001;
@@ -50,7 +49,7 @@ public class IMManager {
     }
 
     public static void makeOff() {
-        if(IMManager.flag == 2000 || IMManager.flag == 500){
+        if (IMManager.flag == 2000 || IMManager.flag == 500) {
             return;
         }
         System.out.println("Stop IM");

--- a/src/main/java/com/ddwhm/jesen/imblocker/ImBlocker.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/ImBlocker.java
@@ -1,20 +1,20 @@
 package com.ddwhm.jesen.imblocker;
 
 
-import net.fabricmc.api.ModInitializer;
-import net.minecraft.SharedConstants;
+import net.fabricmc.api.ClientModInitializer;
 
 
-public class ImBlocker implements ModInitializer {
-	@Override
-	public void onInitialize() {
-		System.out.println("1");
-		String os = System.getProperty("os.name");
-		if(os.toLowerCase().startsWith("win")){
-			IMManager.flag = 200;
-		}else{
-			IMManager.flag = 500;
-		}
-	}
+public class ImBlocker implements ClientModInitializer {
+
+    @Override
+    public void onInitializeClient() {
+        // System.out.println("1");
+        String os = System.getProperty("os.name");
+        if (os.toLowerCase().startsWith("win")) {
+            IMManager.flag = 200;
+        } else {
+            IMManager.flag = 500;
+        }
+    }
 
 }

--- a/src/main/java/com/ddwhm/jesen/imblocker/MixinManager.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/MixinManager.java
@@ -21,13 +21,13 @@ public class MixinManager implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if(!(System.getProperty("os.name").toLowerCase().startsWith("win"))){
+        if (!(System.getProperty("os.name").toLowerCase().startsWith("win"))) {
             return false;
         }
-        if(mixinClassName.endsWith("mixin.AbsButtonMixin") && (SharedConstants.getGameVersion().getName().startsWith("1.15") || SharedConstants.getGameVersion().getName().startsWith("1.14") )){
+        if (mixinClassName.endsWith("mixin.AbsButtonMixin") && (SharedConstants.getGameVersion().getName().startsWith("1.15") || SharedConstants.getGameVersion().getName().startsWith("1.14"))) {
             return false;
         }
-        if(mixinClassName.endsWith("mixin.AnvilScreenMixin") && (SharedConstants.getGameVersion().getName().startsWith("1.15") || SharedConstants.getGameVersion().getName().startsWith("1.14") )){
+        if (mixinClassName.endsWith("mixin.AnvilScreenMixin") && (SharedConstants.getGameVersion().getName().startsWith("1.15") || SharedConstants.getGameVersion().getName().startsWith("1.14"))) {
             return false;
         }
         return true;

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/AbsButtonMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/AbsButtonMixin.java
@@ -11,22 +11,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(AbstractButtonWidget.class)
 public class AbsButtonMixin {
     @Inject(at = @At("RETURN"), method = "setFocused")
-	private void setFocusedMixin(boolean selected, CallbackInfo info) {
-		if(selected){
-			IMManager.makeOn();
-		}else{
-			IMManager.makeOff();
-		}
-	}
+    private void setFocusedMixin(boolean selected, CallbackInfo info) {
+        if (selected) {
+            IMManager.makeOn();
+        } else {
+            IMManager.makeOff();
+        }
+    }
 
-	@Inject(at = @At("RETURN"), method = "isFocused")
-	private void onisFocused(CallbackInfoReturnable<Boolean> cir) {
-		if(cir.getReturnValue()){
-			IMManager.makeOn();
-		}else{
-			IMManager.makeOff();
-		}
+    @Inject(at = @At("RETURN"), method = "isFocused")
+    private void onIsFocused(CallbackInfoReturnable<Boolean> cir) {
+        if (cir.getReturnValue()) {
+            IMManager.makeOn();
+        } else {
+            IMManager.makeOff();
+        }
 
 
-	}
+    }
 }

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/AnvilScreenMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/AnvilScreenMixin.java
@@ -18,12 +18,12 @@ public class AnvilScreenMixin {
     }
 
     @Inject(at = @At("RETURN"), method = "onSlotUpdate")
-    private void onSlotUpdateMixin(ScreenHandler handler, int slotId, ItemStack stack,CallbackInfo info) {
-        if(slotId == 0 && stack.isEmpty()){
+    private void onSlotUpdateMixin(ScreenHandler handler, int slotId, ItemStack stack, CallbackInfo info) {
+        if (slotId == 0 && stack.isEmpty()) {
             IMManager.makeOff();
             //System.out.println("Anvil onStart Off");
         }
-        if(slotId == 0 && !stack.isEmpty()){
+        if (slotId == 0 && !stack.isEmpty()) {
             IMManager.makeOn();
             //System.out.println("Anvil notEmpty On");
         }

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/BookEditMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/BookEditMixin.java
@@ -1,9 +1,7 @@
 package com.ddwhm.jesen.imblocker.mixin;
+
 import com.ddwhm.jesen.imblocker.IMManager;
-import com.ddwhm.jesen.imblocker.ImBlocker;
 import net.minecraft.client.gui.screen.ingame.BookEditScreen;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/ChatMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/ChatMixin.java
@@ -1,7 +1,7 @@
 package com.ddwhm.jesen.imblocker.mixin;
+
 import com.ddwhm.jesen.imblocker.IMManager;
 import net.minecraft.client.gui.screen.ChatScreen;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/CreativeInvMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/CreativeInvMixin.java
@@ -2,7 +2,6 @@ package com.ddwhm.jesen.imblocker.mixin;
 
 
 import com.ddwhm.jesen.imblocker.IMManager;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(CreativeInventoryScreen.class)
 public class CreativeInvMixin {
     @Inject(at = @At("RETURN"), method = "<init>*")
-    private void CreativeInventoryScreenMixin(CallbackInfo info) {
+    private void creativeInventoryScreenMixin(CallbackInfo info) {
         //创造模式物品栏
         System.out.println("creative off");
         IMManager.makeOff();

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/ImBlockerMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/ImBlockerMixin.java
@@ -1,27 +1,19 @@
 package com.ddwhm.jesen.imblocker.mixin;
 
 import com.ddwhm.jesen.imblocker.IMManager;
-import com.ddwhm.jesen.imblocker.ImBlocker;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.screen.ingame.SignEditScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.text.Text;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(TextFieldWidget.class)
 public class ImBlockerMixin {
-	@Inject(at = @At("RETURN"), method = "<init>*")
-	private void onConstructed(CallbackInfo info) {
-		IMManager.makeOn();
+    @Inject(at = @At("RETURN"), method = "<init>*")
+    private void onConstructed(CallbackInfo info) {
+        IMManager.makeOn();
 //		System.out.println("Opened IM!");
-	}
+    }
 
 
 }

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/InventoryMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/InventoryMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(InventoryScreen.class)
 public class InventoryMixin {
     @Inject(at = @At("RETURN"), method = "<init>*")
-    private void InventoryScreenMixin(CallbackInfo info) {
+    private void inventoryScreenMixin(CallbackInfo info) {
         //生存模式物品栏
         System.out.println("survival off");
         IMManager.makeOff();

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/ScreenMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/ScreenMixin.java
@@ -1,10 +1,8 @@
 package com.ddwhm.jesen.imblocker.mixin;
+
 import com.ddwhm.jesen.imblocker.IMManager;
-import com.ddwhm.jesen.imblocker.ImBlocker;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ScreenMixin {
 
     @Inject(at = @At("HEAD"), method = "openScreen")
-    private void openScreenMixin(Screen screen,CallbackInfo info) {
+    private void openScreenMixin(Screen screen, CallbackInfo info) {
         if (screen == null) {
             IMManager.makeOff();
         }

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/SignEditMixin.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/SignEditMixin.java
@@ -1,10 +1,7 @@
 package com.ddwhm.jesen.imblocker.mixin;
+
 import com.ddwhm.jesen.imblocker.IMManager;
-import com.ddwhm.jesen.imblocker.ImBlocker;
 import net.minecraft.client.gui.screen.ingame.SignEditScreen;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,7 +17,7 @@ public class SignEditMixin {
     }
 
     @Inject(at = @At("RETURN"), method = "finishEditing")
-    private void onfinishEditing(CallbackInfo info) {
+    private void onFinishEditing(CallbackInfo info) {
         IMManager.makeOff();
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,6 @@
   "schemaVersion": 1,
   "id": "imblocker",
   "version": "${version}",
-
   "name": "IMBlockerFabric",
   "description": "IMBlockerFabric is a mod that It can Hide IM(InputMethod) when you don't need to input text! This mod fixes the typing bug exist in Minecraft which annoying Asian players for a long time. You can now type multi-byte characters in game using Input Methods (tested in windows platform, with chinese and japanese)",
   "authors": [
@@ -12,24 +11,19 @@
     "homepage": "http://mc.ddwhm.com/",
     "sources": "http://mc.ddwhm.com/#"
   },
-
   "license": "CC0-1.0",
   "icon": "assets/imblocker/icon.png",
-
   "environment": "client",
   "entrypoints": {
-    "main": [
+    "client": [
       "com.ddwhm.jesen.imblocker.ImBlocker"
     ]
   },
   "mixins": [
     "imblocker.mixins.json"
   ],
-
   "depends": {
-    "fabricloader": ">=0.7.4",
-    "fabric": "*",
-    "minecraft": ">=1.14.4"
+    "fabricloader": ">=0.7.4"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
我发现所有代码里只引用了一个Fabric API的类，且这个类不需要安装Fabric API Mod...
于是做了些修改来直接移除Fabric API的整前置需求，顺便规范化了下代码
需要删下gradle缓存

## 更改列表
- 移除了Fabric API前置需求
- 移除了多余的import命令
- 规范化代码

## 以下版本已测试完全兼容
```
Minecraft 1.14.4 - Fabricloader 0.7.4
Minecraft 1.14 - Fabricloader 0.8.0
Minecraft 1.16.3 - Fabricloader 0.9.3
Minecraft 1.16.2 - Fabricloader 0.9.2
```
不兼容的版本应该只有1.14和1.15的快照
问题出自`MixinManager.java`里面的版本判断条件让快照错误的加载了一些Mixin