### PR TITLE
fix crash.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ minecraft_version=1.17
 yarn_mappings=1.17+build.13
 loader_version=0.11.6
 # Mod Properties
-mod_version=1.0.15
+mod_version=1.0.16
 maven_group=com.ddwhm.jesen
 archives_base_name=imblockerfabric

--- a/src/main/java/com/ddwhm/jesen/imblocker/immanager/linux/LinuxImManager.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/immanager/linux/LinuxImManager.java
@@ -8,11 +8,6 @@ import java.io.*;
 public class LinuxImManager implements ImManager {
     private boolean status = true;
 
-
-    public LinuxImManager() {
-        this.makeOff();
-    }
-
     private native void disableIme();
 
     private native void enableIme();

--- a/src/main/java/com/ddwhm/jesen/imblocker/immanager/windows/WindowsImManager.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/immanager/windows/WindowsImManager.java
@@ -27,10 +27,6 @@ public class WindowsImManager implements ImManager {
 
     private static final User32 u = User32.INSTANCE;
 
-    public WindowsImManager() {
-        this.makeOff();
-    }
-
     public void makeOn() {
         ImBlocker.LOGGER.debug("status:{} makeOn", status);
         if (status) {

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinMinecraftClient.java
@@ -3,6 +3,7 @@ package com.ddwhm.jesen.imblocker.mixin;
 import com.ddwhm.jesen.imblocker.ImBlocker;
 import com.ddwhm.jesen.imblocker.util.WidgetManager;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.RunArgs;
 import net.minecraft.client.WindowEventHandler;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.snooper.SnooperListener;
@@ -17,6 +18,11 @@ public abstract class MixinMinecraftClient extends ReentrantThreadExecutor<Runna
 
     public MixinMinecraftClient(String string) {
         super(string);
+    }
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void postInit(RunArgs args, CallbackInfo ci) {
+        ImBlocker.imManager.makeOff();
     }
 
     @Inject(method = "openScreen", at = @At("HEAD"))


### PR DESCRIPTION
预期情况中，imblocker 初始化后会自动禁用输入法，但是目前禁用的时机看起来不太正确，会导致在 windows 下不生效

同时在低版本 mc 的 linux 下，有概率会导致崩溃，因为禁用输入法时 libglfw 还未初始化

因此调节了禁用的时机