### PR TITLE
add compat for minecraft < 1.18.2

### DIFF
--- a/src/main/java/com/ddwhm/jesen/imblocker/MixinManager.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/MixinManager.java
@@ -59,6 +59,19 @@ public class MixinManager implements IMixinConfigPlugin {
         if (mixinClassName.endsWith("mixin.compat115.MixinAbstractButtonWidget") && protocolVersion >= 705) {
             return false;
         }
+        // 1.18.2 compat
+        if (mixinClassName.endsWith("mixin.MixinBookEditScreenLegacy") && protocolVersion >= 758) {
+            return false;
+        }
+        if (mixinClassName.endsWith("mixin.MixinBookEditScreen") && protocolVersion < 758) {
+            return false;
+        }
+        if (mixinClassName.endsWith("mixin.MixinSignEditScreenLegacy") && protocolVersion >= 758) {
+            return false;
+        }
+        if (mixinClassName.endsWith("mixin.MixinSignEditScreen") && protocolVersion < 758) {
+            return false;
+        }
         for (Map.Entry<String, String> entry: mixinDeps.entrySet()) {
             if (mixinClassName.startsWith(entry.getKey())) {
                 return FabricLoader.getInstance().isModLoaded(entry.getValue());

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinBookEditScreenLegacy.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinBookEditScreenLegacy.java
@@ -1,0 +1,30 @@
+package com.ddwhm.jesen.imblocker.mixin;
+
+import com.ddwhm.jesen.imblocker.ImBlocker;
+import com.ddwhm.jesen.imblocker.util.WidgetManager;
+import net.minecraft.client.gui.screen.ingame.BookEditScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BookEditScreen.class)
+public class MixinBookEditScreenLegacy {
+
+    @Inject(at = @At("RETURN"), method = "<init>")
+    private void postInit(CallbackInfo info) {
+        ImBlocker.LOGGER.debug("BookEditScreen.<init>");
+        WidgetManager.updateWidgetStatus(this, true);
+    }
+
+    @Inject(at = @At("RETURN"), method = "finalizeBook")
+    private void preFinalizeBook(CallbackInfo info) {
+        ImBlocker.LOGGER.debug("BookEditScreen.finalizeBook");
+        WidgetManager.updateWidgetStatus(this, false);
+    }
+
+    @Inject(at = @At("RETURN"), method = "tick", remap = false)
+    private void postTick(CallbackInfo ci) {
+        WidgetManager.updateLifeTime(this);
+    }
+}

--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinSignEditScreenLegacy.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/MixinSignEditScreenLegacy.java
@@ -1,0 +1,30 @@
+package com.ddwhm.jesen.imblocker.mixin;
+
+import com.ddwhm.jesen.imblocker.ImBlocker;
+import com.ddwhm.jesen.imblocker.util.WidgetManager;
+import net.minecraft.client.gui.screen.ingame.SignEditScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SignEditScreen.class)
+public class MixinSignEditScreenLegacy {
+
+    @Inject(at = @At("RETURN"), method = "<init>")
+    private void postInit(CallbackInfo info) {
+        ImBlocker.LOGGER.debug("SignEditScreen.<init>");
+        WidgetManager.updateWidgetStatus(this, true);
+    }
+
+    @Inject(at = @At("RETURN"), method = "finishEditing")
+    private void postFinishEditing(CallbackInfo info) {
+        ImBlocker.LOGGER.debug("SignEditScreen.finishEditing");
+        WidgetManager.updateWidgetStatus(this, false);
+    }
+
+    @Inject(at = @At("RETURN"), method = "tick", remap = false)
+    private void postTick(CallbackInfo ci) {
+        WidgetManager.updateLifeTime(this);
+    }
+}

--- a/src/main/resources/imblocker.mixins.json
+++ b/src/main/resources/imblocker.mixins.json
@@ -6,14 +6,16 @@
   "client": [
     "MixinAbstractButtonWidget",
     "MixinBookEditScreen",
+    "MixinBookEditScreenLegacy",
     "MixinMinecraftClient",
     "MixinSignEditScreen",
+    "MixinSignEditScreenLegacy",
     "MixinTextFieldWidget",
-    "rei.MixinTextFieldWidget",
-    "replay.MixinAbstractGuiTextField",
-    "libgui.MixinWWidget",
+    "compat115.MixinAbstractButtonWidget",
     "libgui.MixinWTextField",
-    "compat115.MixinAbstractButtonWidget"
+    "libgui.MixinWWidget",
+    "rei.MixinTextFieldWidget",
+    "replay.MixinAbstractGuiTextField"
   ],
   "plugin": "com.ddwhm.jesen.imblocker.MixinManager",
   "injectors": {


### PR DESCRIPTION
我有问题，1.18.2 的 Screen 类给 tick 方法加了混淆，所以编译出来的代码会不兼容低版本，我给忘了

所以说最新的 imblocker 在低版本会直接 boom，就是不知道为什么一直没人来报告错误