### PR TITLE
Fix crash with REI (#65)

### DIFF
--- a/src/main/java/com/ddwhm/jesen/imblocker/mixin/rei/MixinTextFieldWidget.java
+++ b/src/main/java/com/ddwhm/jesen/imblocker/mixin/rei/MixinTextFieldWidget.java
@@ -16,13 +16,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinTextFieldWidget {
 
     @Dynamic
-    @Inject(at = @At("HEAD"), method = "setFocused")
+    // Fuck remap
+    @Inject(at = @At("HEAD"), method = {"setFocused", "method_25365"})
     private void presetFocused(boolean selected, CallbackInfo info) {
         ImBlocker.LOGGER.debug("ReiTextFieldWidget.setFocused");
         WidgetManager.updateWidgetStatus(this, selected);
     }
     @Dynamic
-    @Inject(method = "isFocused", at = @At("RETURN"))
+    // Fuck remap
+    @Inject(method = {"isFocused", "method_25370"}, at = @At("RETURN"))
     private void postIsFocused(CallbackInfoReturnable<Boolean> cir) {
         // 更新 Widget 存活时间
         ImBlocker.LOGGER.debug("ReiTextFieldWidget.isFocused");


### PR DESCRIPTION
## Reasons for this problem
REI code changes in production environments:
```diff
-   // From RoughlyEnoughItems-10.0.596
-   public boolean isFocused() {
-       return this.focused;
-   }
-
-   public void setFocused(boolean focused) {
-       if (focused && !this.focused) {
-           this.frame = 0;
-       }
-
-       this.focused = focused;
-   }

+   // From RoughlyEnoughItems-11.0.597
+   public boolean method_25370() {
+        return this.focused;
+   }
+
+   public void method_25365(boolean focused) {
+        if (focused && !this.focused) {
+            this.frame = 0;
+        }
+
+        this.focused = focused;
+   }
```
So Mixin targets need intermediary. Still need to keep the original name to be compatible with legacy versions and development environment.

## Test environment
Only tested with MInecraft 1.19.4 + Fabric API 0.76.0+1.19.4 + REI 11.0.597.